### PR TITLE
Optimized double hashing in Bloom filter without altering functionality

### DIFF
--- a/project_bloom/src/bloom_filter.py
+++ b/project_bloom/src/bloom_filter.py
@@ -78,7 +78,6 @@ class BloomFilter:
         data = self._to_bytes(item)
         h1 = int.from_bytes(hashlib.sha256(data).digest(), byteorder="big")
         h2 = int.from_bytes(hashlib.md5(data).digest(), byteorder="big")
-        
         m = self.m
         k = self.k
         return [((h1 + i * h2) % m) for i in range(k)]

--- a/project_bloom/src/bloom_filter.py
+++ b/project_bloom/src/bloom_filter.py
@@ -74,15 +74,14 @@ class BloomFilter:
         return item.encode("utf-8")
 
     def _hashes(self, item: str) -> list[int]:
-    """Generate k Bloom filter indices using double hashing."""
-    data = self._to_bytes(item)
-
-    h1 = int.from_bytes(hashlib.sha256(data).digest(), byteorder="big")
-    h2 = int.from_bytes(hashlib.md5(data).digest(), byteorder="big")
-
-    m = self.m
-    k = self.k
-    return [((h1 + i * h2) % m) for i in range(k)]
+        """Generate k Bloom filter indices using double hashing."""
+        data = self._to_bytes(item)
+        h1 = int.from_bytes(hashlib.sha256(data).digest(), byteorder="big")
+        h2 = int.from_bytes(hashlib.md5(data).digest(), byteorder="big")
+        
+        m = self.m
+        k = self.k
+        return [((h1 + i * h2) % m) for i in range(k)]
 
     def _set_bit(self, index: int) -> None:
         byte_index = index // 8

--- a/project_bloom/src/bloom_filter.py
+++ b/project_bloom/src/bloom_filter.py
@@ -74,13 +74,15 @@ class BloomFilter:
         return item.encode("utf-8")
 
     def _hashes(self, item: str) -> list[int]:
-        data = self._to_bytes(item)
+    """Generate k Bloom filter indices using double hashing."""
+    data = self._to_bytes(item)
 
-        h1 = int(hashlib.sha256(data).hexdigest(), 16)
-        h2 = int(hashlib.md5(data).hexdigest(), 16)
-        hashlib.sha256()
+    h1 = int.from_bytes(hashlib.sha256(data).digest(), byteorder="big")
+    h2 = int.from_bytes(hashlib.md5(data).digest(), byteorder="big")
 
-        return [((h1 + i * h2) % self.m) for i in range(self.k)]
+    m = self.m
+    k = self.k
+    return [((h1 + i * h2) % m) for i in range(k)]
 
     def _set_bit(self, index: int) -> None:
         byte_index = index // 8


### PR DESCRIPTION
I have improved the implementation of hashing in the following ways;

1. replaced hexdigest() with digest() for efficiency by producing hases raw as opposed to hexadecimal string first.
2. used int.from_bytes for direct conversion
3. removed redundant hashlib call
4.  preserved double hashing scheme (h1 + i*h2 mod m)"